### PR TITLE
fix: `Engine` no longer requires Clone for `E`

### DIFF
--- a/examples/custom_engine.rs
+++ b/examples/custom_engine.rs
@@ -18,8 +18,8 @@ use axum::{
 use axum_template::{Key, RenderHtml, TemplateEngine};
 use serde::Serialize;
 
-// Only Clone is required
-#[derive(Debug, Default, Clone)]
+// Clone is required by `axum::extract::Extension`
+#[derive(Debug, Clone)]
 pub struct CustomEngine;
 
 impl TemplateEngine for CustomEngine {
@@ -57,9 +57,7 @@ type AppEngine = CustomEngine;
 
 #[tokio::main]
 async fn main() {
-    // Tera allows loading an entire folder using glob patterns. This will load
-    // our file examples/templates/tera/:name.html with the key :name.html
-    let engine = CustomEngine::default();
+    let engine = CustomEngine;
     let app = Router::new()
         .route("/:name", get(get_name))
         // Share the engine using `axum::Extension`, or implement `tower::Layer`

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -74,10 +74,7 @@ impl<E> From<E> for Engine<E> {
     }
 }
 
-impl<S, E> Layer<S> for Engine<E>
-where
-    E: Clone,
-{
+impl<S, E> Layer<S> for Engine<E> {
     type Service = AddExtension<S, Self>;
 
     fn layer(&self, inner: S) -> Self::Service {
@@ -88,7 +85,7 @@ where
 #[async_trait]
 impl<B, E> FromRequest<B> for Engine<E>
 where
-    Self: Clone + Send + Sync + 'static,
+    Self: Send + Sync + 'static,
     B: Send,
 {
     type Rejection = EngineRejection;

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -22,7 +22,7 @@ use axum::{
     response::IntoResponse,
     Extension,
 };
-use std::sync::Arc;
+use std::{fmt::Debug, sync::Arc};
 use tower_http::add_extension::AddExtension;
 use tower_layer::Layer;
 
@@ -46,7 +46,7 @@ pub use self::minijinja::*;
 /// and examples
 ///
 /// [`TemplateEngine`]: crate::TemplateEngine
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct Engine<E> {
     #[allow(dead_code)]
     engine: Arc<E>,
@@ -57,6 +57,14 @@ impl<E> Engine<E> {
     pub fn new(engine: E) -> Self {
         let engine = Arc::new(engine);
         Self { engine }
+    }
+}
+
+impl<E> Clone for Engine<E> {
+    fn clone(&self) -> Self {
+        Self {
+            engine: self.engine.clone(),
+        }
     }
 }
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -10,7 +10,7 @@ use serde::Serialize;
 /// # use serde::Serialize;
 /// # use std::convert::Infallible;
 ///
-/// #[derive(Debug, Default, Clone)]
+/// #[derive(Debug)]
 /// pub struct CustomEngine;
 ///
 /// impl TemplateEngine for CustomEngine {


### PR DESCRIPTION
This fixes a trait bounds error related to the `Clone` derive macro. `E: Clone` is no longer required

See `Arc` docs: https://doc.rust-lang.org/std/sync/struct.Arc.html#impl-Clone