### PR TITLE
fix: #8. Infinite recursion on IntoResponse for error types

### DIFF
--- a/src/engine/handlebars.rs
+++ b/src/engine/handlebars.rs
@@ -26,6 +26,6 @@ pub enum HandlebarsError {
 
 impl IntoResponse for HandlebarsError {
     fn into_response(self) -> axum::response::Response {
-        (StatusCode::INTERNAL_SERVER_ERROR, self).into_response()
+        (StatusCode::INTERNAL_SERVER_ERROR, self.to_string()).into_response()
     }
 }

--- a/src/engine/minijinja.rs
+++ b/src/engine/minijinja.rs
@@ -27,6 +27,6 @@ pub enum MinijinjaError {
 
 impl IntoResponse for MinijinjaError {
     fn into_response(self) -> axum::response::Response {
-        (StatusCode::INTERNAL_SERVER_ERROR, self).into_response()
+        (StatusCode::INTERNAL_SERVER_ERROR, self.to_string()).into_response()
     }
 }

--- a/src/engine/tera.rs
+++ b/src/engine/tera.rs
@@ -27,6 +27,6 @@ pub enum TeraError {
 
 impl IntoResponse for TeraError {
     fn into_response(self) -> axum::response::Response {
-        (StatusCode::INTERNAL_SERVER_ERROR, self).into_response()
+        (StatusCode::INTERNAL_SERVER_ERROR, self.to_string()).into_response()
     }
 }

--- a/tests/error.rs
+++ b/tests/error.rs
@@ -1,0 +1,44 @@
+//! Regression tests for stack overflow on IntoResponse calls for error types
+//!
+//! See https://github.com/Altair-Bueno/axum-template/issues/8
+
+use axum::response::IntoResponse;
+use axum_template::engine::Engine;
+use axum_template::Render;
+use rstest::*;
+
+#[cfg(feature = "tera")]
+#[rstest]
+#[trace]
+#[tokio::test]
+async fn tera_error_into_response_check_infinite_recursion() -> anyhow::Result<()> {
+    let engine = tera::Tera::new("*.nothing")?;
+    let engine = Engine::new(engine);
+    let data = ();
+    _ = Render("", engine, data).into_response();
+    Ok(())
+}
+
+#[cfg(feature = "handlebars")]
+#[rstest]
+#[trace]
+#[tokio::test]
+async fn handlebars_error_into_response_check_infinite_recursion() -> anyhow::Result<()> {
+    let engine = handlebars::Handlebars::new();
+    let engine = Engine::new(engine);
+    let data = ();
+    _ = Render("", engine, data).into_response();
+    Ok(())
+}
+
+#[cfg(feature = "minijinja")]
+#[rstest]
+#[trace]
+#[tokio::test]
+async fn minijinja_error_into_response_check_infinite_recursion() -> anyhow::Result<()> {
+    let engine = minijinja::Environment::new();
+    let engine = Engine::new(engine);
+    let data = ();
+    _ = Render("", engine, data).into_response();
+    Ok(())
+}


### PR DESCRIPTION
Fixes #8 