### PR TITLE
fix: #32.  Add `#[must_use]` to `Render` and `RenderHtml`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "axum-template"
-version = "0.19.0"
+version = "1.0.0"
 edition = "2021"
 license = "MIT"
 description = "Layers, extractors and template engine wrappers for axum based Web MVC applications"

--- a/src/render.rs
+++ b/src/render.rs
@@ -27,6 +27,7 @@ use crate::TemplateEngine;
 /// }
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[must_use]
 pub struct Render<K, E, S>(pub K, pub E, pub S);
 
 impl<K, E, S> IntoResponse for Render<K, E, S>
@@ -71,6 +72,7 @@ where
 /// }
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[must_use]
 pub struct RenderHtml<K, E, S>(pub K, pub E, pub S);
 
 impl<K, E, S> IntoResponse for RenderHtml<K, E, S>


### PR DESCRIPTION
The reason for the major version bump is that `must_use` now outputs a warning that might be a breaking change for some codebases. No other changes are included.
